### PR TITLE
Set protractor to version "^3.3.0", set async to version "^2.0.0-rc.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wt-protractor-runner",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Gulp (or anywhere else) protractor runner task",
     "main": "index.js",
     "repository": {
@@ -24,10 +24,10 @@
     },
     "homepage": "https://github.com/wishtack/wt-protractor-runer",
     "dependencies": {
-        "async": "1.5.0",
+        "async": "^2.0.0-rc.5",
         "dejavu": "0.4.8",
         "jasmine-node": "git://github.com/mhevery/jasmine-node.git#Jasmine2.0",
-        "protractor": "3.0.0",
+        "protractor": "^3.3.0",
         "string-format": "0.5.0",
         "temp": "0.8.3",
         "underscore": "1.8.3"


### PR DESCRIPTION
As `protractor@3.0.0` introduced vulnerabilities according to [nsp](https://nodesecurity.io/advisories/67).
Including a drive-by version bumper for async 😄 
